### PR TITLE
パスにバージョン指定がないときはデフォルトのバージョンを参照するように

### DIFF
--- a/DataManager/ReportForm/src/Product/ReportForm/Instance.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Instance.ts
@@ -49,6 +49,7 @@ import { UnitReportGroupListWebsiteController, UnitReportGroupListWebsiteParamet
 import { UnitReportGroupWebsiteController, UnitReportGroupWebsiteParameter } from "./Layer3/WebsiteControllers/UnitReportGroup/UnitReportGroupWebsiteController";
 import { UnverifiedListByGenreWebsiteController, UnverifiedListByGenreWebsiteParameter } from "./Layer3/WebsiteControllers/UnverifiedList/UnverifiedListByGenreWebsiteController";
 import { UnverifiedListByLevelWebsiteController, UnverifiedListByLevelWebsiteParameter } from "./Layer3/WebsiteControllers/UnverifiedList/UnverifiedListByLevelWebsiteController";
+import { RoutingNodeHandler } from "../../Packages/Router/RoutingNodeHandler";
 
 export class Instance {
     private static _instance: Instance = null;
@@ -139,6 +140,16 @@ export class Instance {
         router.findNodeByName(LevelReportWebsiteController).bindController(() => new LevelReportWebsiteController(e));
         router.findNodeByName(UnverifiedListByGenreWebsiteController).bindController(() => new UnverifiedListByGenreWebsiteController(e));
         router.findNodeByName(UnverifiedListByLevelWebsiteController).bindController(() => new UnverifiedListByLevelWebsiteController(e));
+
+        router.getOrCreateNode("/").bindController(() => new TopWebsiteController(e));
+        router.getOrCreateNode("/unitReportList").bindController(() => new UnitReportListWebsiteController(e));
+        router.getOrCreateNode(`/unitReport/reportId:${RoutingParameterType.TEXT}`).bindController(() => new UnitReportWebsiteController(e));
+        router.getOrCreateNode("/unitReportGroupList").bindController(() => new UnitReportGroupListWebsiteController(e));
+        router.getOrCreateNode(`/unitReportGroup/groupId:${RoutingParameterType.TEXT}`).bindController(() => new UnitReportGroupWebsiteController(e));
+        router.getOrCreateNode("/levelReportList").bindController(() => new LevelReportListWebsiteController(e));
+        router.getOrCreateNode(`/levelReport/reportId:${RoutingParameterType.TEXT}`).bindController(() => new LevelReportWebsiteController(e));
+        router.getOrCreateNode("/unverifiedListByGenre").bindController(() => new UnverifiedListByGenreWebsiteController(e));
+        router.getOrCreateNode("/unverifiedListByLevel").bindController(() => new UnverifiedListByLevelWebsiteController(e));
     }
 
     public setupLINEPostCommandControllers(): void {

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer2/Modules/VersionModule.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer2/Modules/VersionModule.ts
@@ -2,6 +2,8 @@ import { VersionConfigurationSchema } from "../../Layer1/Configurations/Configur
 import { ReportFormModule } from "./@ReportFormModule";
 
 export class VersionModule extends ReportFormModule {
+    public static readonly moduleName = 'version';
+
     public getVersionConfig(versionName: string): VersionConfigurationSchema {
         return this.configuration.versions[versionName];
     }

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/@ReportFormController.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/@ReportFormController.ts
@@ -75,6 +75,9 @@ export class ReportFormWebsiteController<TParameter extends ReportFormWebsitePar
     }
 
     protected getFullPath<TParam extends ReportFormWebsiteParameter>(parameter: TParam, targetController: { prototype: RoutingControllerWithType<TParam>; name: string }): string {
+        if (!parameter.version) {
+            parameter.version = this.targetGameVersion;
+        }
         return ReportFormWebsiteController.getFullPath(this.configuration, this.router, targetController, parameter)
     }
 

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/@ReportFormController.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/@ReportFormController.ts
@@ -32,11 +32,24 @@ export class ReportFormWebsiteController<TParameter extends ReportFormWebsitePar
         return true;
     }
 
+    private _targetGameVersion: string = null;
+    protected get targetGameVersion(): string {
+        return this._targetGameVersion;
+    }
+
     public call(parameter: Readonly<TParameter>, node: RoutingNode): GoogleAppsScript.HTML.HtmlOutput {
         if (!this.isAccessale(this.configuration.role)) {
             CustomLogManager.log(LogLevel.Error, `権限のないページにアクセスされました\n対象ページ: ${node.getFullPath(parameter)}`);
             throw new Error("存在しないページが指定されました");
         }
+
+        if (parameter.version) {
+            this._targetGameVersion = parameter.version;
+        }
+        else {
+            this._targetGameVersion = this.configuration.defaultVersionName;
+        }
+
         return this.callInternal(parameter, node);
     }
 

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/@ReportFormController.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/@ReportFormController.ts
@@ -57,7 +57,7 @@ export class ReportFormWebsiteController<TParameter extends ReportFormWebsitePar
         throw new Error("Method not implemented.");
     }
 
-    protected getModule<T extends ReportFormModule>(module: { new(): T; moduleName: string }): T {
+    protected getModule<T extends ReportFormModule>(module: { new(): T }): T {
         return this.module.getModule(module);
     }
 

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/LevelReport/LevelReportListWebsiteController.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/LevelReport/LevelReportListWebsiteController.ts
@@ -21,9 +21,9 @@ export class LevelReportListWebsiteController extends ReportFormWebsiteControlle
     }
 
     protected callInternal(parameter: LevelReportListWebsiteParameter, node: RoutingNode): GoogleAppsScript.HTML.HtmlOutput {
-        const listHtml = this.reportModule.getLevelBulkReports(parameter.version)
+        const listHtml = this.reportModule.getLevelBulkReports(this.targetGameVersion)
             .filter(r => r.reportStatus === ReportStatus.InProgress)
-            .map(report => this.getListItemHtml(parameter.version, report))
+            .map(report => this.getListItemHtml(this.targetGameVersion, report))
             .reduce((acc, src) => `${acc}\n${src}`, '');
 
         let source = this.readHtml("Resources/Page/wip_bulk_report_list/main");
@@ -39,7 +39,7 @@ export class LevelReportListWebsiteController extends ReportFormWebsiteControlle
         const date = report.reportDate;
         const dateText = LevelReportListWebsiteController.getDateText(date);
         const parameter: LevelReportWebsiteParameter = {
-            version: version,
+            version: this.targetGameVersion,
             reportId: report.reportId.toString(),
         };
         const url = this.getFullPath(parameter, LevelReportWebsiteController);

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/LevelReport/LevelReportWebsiteController.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/LevelReport/LevelReportWebsiteController.ts
@@ -20,7 +20,7 @@ export class LevelReportWebsiteController extends ReportFormWebsiteController<Le
 
     protected callInternal(parameter: LevelReportWebsiteParameter, node: RoutingNode): GoogleAppsScript.HTML.HtmlOutput {
         const reportId = parseInt(parameter.reportId);
-        const report = this.reportModule.getLevelBulkReportSheet(parameter.version).getBulkReport(reportId);
+        const report = this.reportModule.getLevelBulkReportSheet(this.targetGameVersion).getBulkReport(reportId);
 
         if (!report) {
             throw new Error("該当する検証報告が存在しません");
@@ -28,7 +28,7 @@ export class LevelReportWebsiteController extends ReportFormWebsiteController<Le
 
         let source = this.readHtml("Resources/Page/bulk_approval/main");
 
-        source = source.replace(/%versionName%/g, parameter.version);
+        source = source.replace(/%versionName%/g, this.targetGameVersion);
         source = this.replacePageLink(source, parameter, LevelReportWebsiteController);
         source = this.replacePageLink(source, parameter, LevelReportListWebsiteController);
 

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/TopWebsiteController.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/TopWebsiteController.ts
@@ -17,7 +17,7 @@ export class TopWebsiteController extends ReportFormWebsiteController<TopWebsite
     private get versionModule() { return this.getModule(VersionModule); }
 
     protected callInternal(parameter: Readonly<TopWebsiteParameter>, node: RoutingNode): GoogleAppsScript.HTML.HtmlOutput {
-        const versionText = this.versionModule.getVersionConfig(parameter.version).displayVersionName;
+        const versionText = this.versionModule.getVersionConfig(this.targetGameVersion).displayVersionName;
 
         let source = this.readHtml("Resources/Page/top/main");
 

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/UnitReport/UnitReportListWebsiteController.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/UnitReport/UnitReportListWebsiteController.ts
@@ -20,9 +20,9 @@ export class UnitReportListWebsiteController extends ReportFormWebsiteController
     }
 
     protected callInternal(parameter: UnitReportListWebsiteParameter, node: RoutingNode): GoogleAppsScript.HTML.HtmlOutput {
-        const listHtml = this.reportModule.getReports(parameter.version)
+        const listHtml = this.reportModule.getReports(this.targetGameVersion)
             .filter(r => r.reportStatus === ReportStatus.InProgress)
-            .map(r => this.getListItemHtml(parameter.version, r))
+            .map(r => this.getListItemHtml(this.targetGameVersion, r))
             .reduce((acc, src) => `${acc}\n${src}`, '');
 
         let source = this.readHtml("Resources/Page/wip_list/main");
@@ -36,7 +36,7 @@ export class UnitReportListWebsiteController extends ReportFormWebsiteController
 
     private getListItemHtml(version: string, report: IReport): string {
         const parameter: UnitReportWebsiteParameter = {
-            version: version,
+            version: this.targetGameVersion,
             reportId: report.reportId.toString(),
         };
         const path = this.getFullPath(parameter, UnitReportWebsiteController);

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/UnitReport/UnitReportWebsiteController.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/UnitReport/UnitReportWebsiteController.ts
@@ -20,7 +20,7 @@ export class UnitReportWebsiteController extends ReportFormWebsiteController<Uni
 
     public callInternal(parameter: UnitReportWebsiteParameter, node: RoutingNode): GoogleAppsScript.HTML.HtmlOutput {
         const reportId = parseInt(parameter.reportId);
-        const report = this.reportModule.getReport(parameter.version, reportId);
+        const report = this.reportModule.getReport(this.targetGameVersion, reportId);
         if (!report) {
             throw new Error("該当する検証報告が存在しません");
         }
@@ -34,7 +34,7 @@ export class UnitReportWebsiteController extends ReportFormWebsiteController<Uni
 
         let source = this.readHtml("Resources/Page/approval/main");
 
-        source = source.replace(/%versionName%/g, parameter.version);
+        source = source.replace(/%versionName%/g, this.targetGameVersion);
         source = this.replacePageLink(source, parameter, UnitReportWebsiteController);
         source = this.replacePageLink(source, parameter, UnitReportListWebsiteController);
 

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/UnitReportGroup/UnitReportGroupListWebsiteController.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/UnitReportGroup/UnitReportGroupListWebsiteController.ts
@@ -21,11 +21,11 @@ export class UnitReportGroupListWebsiteController extends ReportFormWebsiteContr
     }
 
     protected callInternal(parameter: UnitReportGroupListWebsiteParameter, node: RoutingNode): GoogleAppsScript.HTML.HtmlOutput {
-        const reportGroups = this.reportModule.getMusicDataReportGroupContainer(parameter.version).musicDataReportGroups;
-        const listHtml = this.getListHtml(parameter.version, reportGroups);
+        const reportGroups = this.reportModule.getMusicDataReportGroupContainer(this.targetGameVersion).musicDataReportGroups;
+        const listHtml = this.getListHtml(this.targetGameVersion, reportGroups);
 
         let source = this.readHtml("Resources/Page/report_group_list/main");
-        source = source.replace(/%versionName%/g, parameter.version);
+        source = source.replace(/%versionName%/g, this.targetGameVersion);
         source = this.replacePageLink(source, parameter, TopWebsiteController);
         source = source.replace(/%list%/g, listHtml);
 
@@ -71,7 +71,7 @@ export class UnitReportGroupListWebsiteController extends ReportFormWebsiteContr
             }
         }
         const parameter: UnitReportGroupWebsiteParameter = {
-            version: version,
+            version: this.targetGameVersion,
             groupId: reportGroup.groupId,
         };
         const url = this.getFullPath(parameter, UnitReportGroupWebsiteController);

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/UnitReportGroup/UnitReportGroupWebsiteController.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/UnitReportGroup/UnitReportGroupWebsiteController.ts
@@ -28,9 +28,9 @@ export class UnitReportGroupWebsiteController extends ReportFormWebsiteControlle
     }
 
     public callInternal(parameter: UnitReportGroupWebsiteParameter, node: RoutingNode): GoogleAppsScript.HTML.HtmlOutput {
-        const table = this.musicDataModule.getTable(parameter.version);
+        const table = this.musicDataModule.getTable(this.targetGameVersion);
         const reportGroup = this.reportModule
-            .getMusicDataReportGroupContainer(parameter.version)
+            .getMusicDataReportGroupContainer(this.targetGameVersion)
             .getMusicDataReportGroup(parameter.groupId);
         console.log(parameter.groupId);
         if (!reportGroup) {
@@ -41,7 +41,7 @@ export class UnitReportGroupWebsiteController extends ReportFormWebsiteControlle
 
         let source = this.readHtml("Resources/Page/group_approval/main");
 
-        source = source.replace(/%versionName%/g, parameter.version);
+        source = source.replace(/%versionName%/g, this.targetGameVersion);
         source = this.replacePageLink(source, parameter, UnitReportGroupWebsiteController);
         source = this.replacePageLink(source, parameter, UnitReportGroupListWebsiteController);
 

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/UnverifiedList/UnverifiedListByGenreWebsiteController.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/UnverifiedList/UnverifiedListByGenreWebsiteController.ts
@@ -40,10 +40,10 @@ export class UnverifiedListByGenreWebsiteController extends ReportFormWebsiteCon
         source = this.replacePageLink(source, parameter, TopWebsiteController);
         source = this.replacePageLink(source, parameter, UnverifiedListByGenreWebsiteController);
 
-        const genres = this.versionModule.getVersionConfig(parameter.version).genres;
+        const genres = this.versionModule.getVersionConfig(this.targetGameVersion).genres;
         source = source.replace(/%difficulty_select_list%/g, this.getDifficultySelectListHtml(this.doGetParameter.parameter));
         source = source.replace(/%genre_select_list%/g, this.getGenreSelectListHtml(this.doGetParameter.parameter, genres));
-        source = source.replace(/%list%/g, this.getListHtml(parameter.version, this.doGetParameter.parameter, genres))
+        source = source.replace(/%list%/g, this.getListHtml(this.targetGameVersion, this.doGetParameter.parameter, genres))
 
         return this.createHtmlOutput(source);
     }

--- a/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/UnverifiedList/UnverifiedListByLevelWebsiteController.ts
+++ b/DataManager/ReportForm/src/Product/ReportForm/Layer3/WebsiteControllers/UnverifiedList/UnverifiedListByLevelWebsiteController.ts
@@ -43,7 +43,7 @@ export class UnverifiedListByLevelWebsiteController extends ReportFormWebsiteCon
 
         source = source.replace(/%difficulty_select_list%/g, this.getDifficultySelectListHtml(this.doGetParameter.parameter));
         source = source.replace(/%levelList%/, this.getSelectLevelListHtml(this.doGetParameter.parameter));
-        source = source.replace(/%list%/g, this.getListHtml(parameter.version, this.doGetParameter.parameter));
+        source = source.replace(/%list%/g, this.getListHtml(this.targetGameVersion, this.doGetParameter.parameter));
 
         return this.createHtmlOutput(source);
     }


### PR DESCRIPTION
#### Changed
- 参照するゲームバージョンのプロパティ定義を基底モジュールで定義してその値を参照するよう置き換え
- バージョン指定を含まないルーティングの構築